### PR TITLE
cgo: bindings add `Load()` and deprecate `Auto()`/`Cancel()`

### DIFF
--- a/cgo/lib.go
+++ b/cgo/lib.go
@@ -7,27 +7,15 @@ package vec
 import "C"
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/binary"
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
 )
-
-// Once called, every future new SQLite3 connection created in this process
-// will have the sqlite-vec extension loaded. It will persist until [Cancel] is
-// called.
-//
-// Calls [sqlite3_auto_extension()] under the hood.
-//
-// [sqlite3_auto_extension()]: https://www.sqlite.org/c3ref/auto_extension.html
-func Auto() {
-	C.sqlite3_auto_extension( (*[0]byte) ((C.sqlite3_vec_init)) );
-}
-
-// "Cancels" any previous calls to [Auto]. Any new SQLite3 connections created
-// will not have the sqlite-vec extension loaded.
-//
-// Calls sqlite3_cancel_auto_extension() under the hood.
-func Cancel() {
-	C.sqlite3_cancel_auto_extension( (*[0]byte) (C.sqlite3_vec_init) );
-}
 
 // Serializes a float32 list into a vector BLOB that sqlite-vec accepts.
 func SerializeFloat32(vector []float32) ([]byte, error) {
@@ -39,3 +27,28 @@ func SerializeFloat32(vector []float32) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Loads the sqlite-vec extension into the given database connection.
+// The connection must be a *sqlite3.SQLiteConn from github.com/mattn/go-sqlite3.
+// Beware! this unsafe and reflection to access the underlying C pointer.
+func Load(db *sql.DB) error {
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return conn.Raw(func(driverConn interface{}) error {
+		sc, ok := driverConn.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("not sqlite3 conn")
+		}
+		dbVal := reflect.ValueOf(sc).Elem().FieldByName("db")
+		dbPtr := unsafe.Pointer(dbVal.Pointer())
+		raw := (*C.sqlite3)(dbPtr)
+		rc := C.sqlite3_vec_init(raw, nil, nil)
+		if rc != C.SQLITE_OK {
+			return fmt.Errorf("sqlite3_vec_init failed: %d", int32(rc))
+		}
+
+		return nil
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.5
 require github.com/ncruces/go-sqlite3 v0.17.1
 
 require (
+	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/tetratelabs/wazero v1.7.3 // indirect
 	golang.org/x/sys v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
+github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/ncruces/go-sqlite3 v0.17.1 h1:VxTjDpCn87FaFlKMaAYC1jP7ND0d4UNj+6G4IQDHbgI=
 github.com/ncruces/go-sqlite3 v0.17.1/go.mod h1:FnCyui8SlDoL0mQZ5dTouNo7s7jXS0kJv9lBt1GlM9w=
 github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=


### PR DESCRIPTION
The use of `sqlite3_auto_extension()` has always been hacky, but also brings deprecation warnings on recent MacOS builds (see https://github.com/asg017/sqlite-vec/issues/)

So this takes a new approach — all we need is the raw `C.sqlite3` pointer of a SQLite connection, to which then we cann `sqlite3_vec_init()` and load in all `sqlite-vec` functions. 

The mattn bindings dont expose that pointer directly, so we have to hack around it with reflect/unsafe code. 

tbh I'm not 100% sure this is the right move — reflect seems pretty hacky and idk what implications there are for this. 

If any Go devs wanna weight in, please do. I do enjoy the `sqlite_vec.Load(conn)` API over the global `sqlite_vec.Auto()`, which can have unintended side-effects.


```go
package main

import (
	"database/sql"
	"log"

	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
	_ "github.com/mattn/go-sqlite3"
)

import "C"

func main() {
	db, err := sql.Open("sqlite3", ":memory:")
	sqlite_vec.Load(db)
	if err != nil {
		log.Fatal(err)
	}
	defer db.Close()

	var sqliteVersion string
	var vecVersion string
	err = db.QueryRow("select sqlite_version(), vec_version()").Scan(&sqliteVersion, &vecVersion)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("sqlite_version=%s, vec_version=%s\n", sqliteVersion, vecVersion)
}
```


```
› go run main.go
2025/09/19 11:12:31 sqlite_version=3.50.4, vec_version=v0.1.7-alpha.2
```
